### PR TITLE
periodically refresh dns name

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -56,7 +56,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
 
     this.cacheDns = options.cacheDns;
     // a default like /dev/null to send the metrics to. So the process won't crash even the name resolution fails.
-    this.resolvedAddress = "127.0.0.1";
+    this.resolvedAddress = null;
     if(options.cacheDns === true){
         this.refreshDns();
     }
@@ -309,7 +309,7 @@ Client.prototype.sendMessage = function(message, callback){
     var buf = new Buffer(message);
     this.refreshSocketAndDns();
 
-    var address = this.cacheDns ? this.resolvedAddress : this.host;
+    var address = this.resolvedAddress || this.host;
     this.socket.send(buf, 0, buf.length, this.port, address, callback);
 }
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -9,7 +9,7 @@ var dgram = require('dgram'),
  *   @option prefix      {String}  An optional prefix to assign to each stat name sent
  *   @option suffix      {String}  An optional suffix to assign to each stat name sent
  *   @option globalize   {boolean} An optional boolean to add "statsd" as an object in the global namespace
- *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
+ *   @option cacheDns    {boolean} An optional option to cache dns result and refresh periodically.
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
  *   @maxBufferSize      {Number} An optional value for aggregating metrics to send, mainly for performance improvement
@@ -18,53 +18,52 @@ var dgram = require('dgram'),
  * @constructor
  */
 var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval, socketRefreshInterval) {
-  var options = host || {},
-         self = this;
+    var options = host || {},
+        self = this;
 
-  if(arguments.length > 1 || typeof(host) === 'string'){
-    options = {
-      host        : host,
-      port        : port,
-      prefix      : prefix,
-      suffix      : suffix,
-      globalize   : globalize,
-      cacheDns    : cacheDns,
-      mock        : mock === true,
-      global_tags : global_tags,
-      maxBufferSize : maxBufferSize,
-      bufferFlushInterval: bufferFlushInterval,
-      socketRefreshInterval: socketRefreshInterval
-    };
-  }
+    if(arguments.length > 1 || typeof(host) === 'string'){
+        options = {
+            host        : host,
+            port        : port,
+            prefix      : prefix,
+            suffix      : suffix,
+            globalize   : globalize,
+            cacheDns    : cacheDns,
+            mock        : mock === true,
+            global_tags : global_tags,
+            maxBufferSize : maxBufferSize,
+            bufferFlushInterval: bufferFlushInterval,
+            socketRefreshInterval: socketRefreshInterval
+        };
+    }
 
-  this.host        = options.host || 'localhost';
-  this.port        = options.port || 8125;
-  this.prefix      = options.prefix || '';
-  this.suffix      = options.suffix || '';
-  this.socket      = dgram.createSocket('udp4');
-  this.socketCreateTime = new Date();
-  this.mock        = options.mock;
-  this.global_tags = options.global_tags || [];
-  this.maxBufferSize = options.maxBufferSize || 0;
-  this.bufferFlushInterval = options.bufferFlushInterval || 1000;
-  this.buffer = "";
-  this.socketRefreshInterval = options.socketRefreshInterval || 60000; // 1 minute
+    this.host        = options.host || 'localhost';
+    this.port        = options.port || 8125;
+    this.prefix      = options.prefix || '';
+    this.suffix      = options.suffix || '';
+    this.socket      = dgram.createSocket('udp4');
+    this.socketCreateTime = new Date();
+    this.mock        = options.mock;
+    this.global_tags = options.global_tags || [];
+    this.maxBufferSize = options.maxBufferSize || 0;
+    this.bufferFlushInterval = options.bufferFlushInterval || 1000;
+    this.buffer = "";
+    this.socketRefreshInterval = options.socketRefreshInterval || 60000; // 1 minute
 
-  if(this.maxBufferSize > 0) {
-    this.intervalHandle = setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
-  }
+    if(this.maxBufferSize > 0) {
+        this.intervalHandle = setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
+    }
 
-  if(options.cacheDns === true){
-    dns.lookup(options.host, function(err, address, family){
-      if(err == null){
-        self.host = address;
-      }
-    });
-  }
+    this.cacheDns = options.cacheDns;
+    // a default like /dev/null to send the metrics to. So the process won't crash even the name resolution fails.
+    this.resolvedAddress = "127.0.0.1";
+    if(options.cacheDns === true){
+        this.refreshDns();
+    }
 
-  if(options.globalize){
-    global.statsd = this;
-  }
+    if(options.globalize){
+        global.statsd = this;
+    }
 };
 
 /**
@@ -76,7 +75,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
-  this.sendAll(stat, time, 'ms', sampleRate, tags, callback);
+    this.sendAll(stat, time, 'ms', sampleRate, tags, callback);
 };
 
 /**
@@ -88,7 +87,7 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
+    this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
 };
 
 /**
@@ -100,7 +99,7 @@ Client.prototype.increment = function (stat, value, sampleRate, tags, callback) 
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
+    this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
 };
 
 /**
@@ -112,7 +111,7 @@ Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) 
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.histogram = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 'h', sampleRate, tags, callback);
+    this.sendAll(stat, value, 'h', sampleRate, tags, callback);
 };
 
 
@@ -125,7 +124,7 @@ Client.prototype.histogram = function (stat, value, sampleRate, tags, callback) 
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 'g', sampleRate, tags, callback);
+    this.sendAll(stat, value, 'g', sampleRate, tags, callback);
 };
 
 /**
@@ -137,9 +136,9 @@ Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.unique =
-Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 's', sampleRate, tags, callback);
-};
+    Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
+        this.sendAll(stat, value, 's', sampleRate, tags, callback);
+    };
 
 /**
  * Checks if stats is an array and sends all stats calling back once all have sent
@@ -150,51 +149,51 @@ Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callback){
-  var completed = 0,
-      calledback = false,
-      sentBytes = 0,
-      self = this;
+    var completed = 0,
+    calledback = false,
+    sentBytes = 0,
+    self = this;
 
-  if(sampleRate && typeof sampleRate !== 'number'){
-    callback = tags;
-    tags = sampleRate;
-    sampleRate = undefined;
-  }
-
-  if(tags && !Array.isArray(tags)){
-    callback = tags;
-    tags = undefined;
-  }
-
-  /**
-   * Gets called once for each callback, when all callbacks return we will
-   * call back from the function
-   * @private
-   */
-  function onSend(error, bytes){
-    completed += 1;
-    if(calledback || typeof callback !== 'function'){
-      return;
+    if(sampleRate && typeof sampleRate !== 'number'){
+        callback = tags;
+        tags = sampleRate;
+        sampleRate = undefined;
     }
 
-    if(error){
-      calledback = true;
-      return callback(error);
+    if(tags && !Array.isArray(tags)){
+        callback = tags;
+        tags = undefined;
     }
 
-    sentBytes += bytes;
-    if(completed === stat.length){
-      callback(null, sentBytes);
-    }
-  }
+    /**
+     * Gets called once for each callback, when all callbacks return we will
+     * call back from the function
+     * @private
+     */
+    function onSend(error, bytes){
+        completed += 1;
+        if(calledback || typeof callback !== 'function'){
+            return;
+        }
 
-  if(Array.isArray(stat)){
-    stat.forEach(function(item){
-      self.send(item, value, type, sampleRate, tags, onSend);
-    });
-  } else {
-    this.send(stat, value, type, sampleRate, tags, callback);
-  }
+        if(error){
+            calledback = true;
+            return callback(error);
+        }
+
+        sentBytes += bytes;
+        if(completed === stat.length){
+            callback(null, sentBytes);
+        }
+    }
+
+    if(Array.isArray(stat)){
+        stat.forEach(function(item){
+            self.send(item, value, type, sampleRate, tags, onSend);
+        });
+    } else {
+        this.send(stat, value, type, sampleRate, tags, callback);
+    }
 };
 
 /**
@@ -207,42 +206,42 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.send = function (stat, value, type, sampleRate, tags, callback) {
-  var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
-      merged_tags = [];
+    var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
+        merged_tags = [];
 
-  if(sampleRate && sampleRate < 1){
-    if(Math.random() < sampleRate){
-      message += '|@' + sampleRate;
-    } else {
-      //don't want to send if we don't meet the sample ratio
-      return;
+    if(sampleRate && sampleRate < 1){
+        if(Math.random() < sampleRate){
+            message += '|@' + sampleRate;
+        } else {
+            //don't want to send if we don't meet the sample ratio
+            return;
+        }
     }
-  }
 
-  if(tags && Array.isArray(tags)){
-    merged_tags = merged_tags.concat(tags);
-  }
-  if(this.global_tags && Array.isArray(this.global_tags)){
-    merged_tags = merged_tags.concat(this.global_tags);
-  }
-  if(merged_tags.length > 0){
-    message += '|#' + merged_tags.join(',');
-  }
-
-  // Only send this stat if we're not a mock Client.
-  if(!this.mock) {
-      if(this.maxBufferSize === 0) {
-          this.sendMessage(message, callback);
-      }
-      else {
-          this.enqueue(message);
-      }
-  }
-  else {
-    if(typeof callback === 'function'){
-      callback(null, 0);
+    if(tags && Array.isArray(tags)){
+        merged_tags = merged_tags.concat(tags);
     }
-  }
+    if(this.global_tags && Array.isArray(this.global_tags)){
+        merged_tags = merged_tags.concat(this.global_tags);
+    }
+    if(merged_tags.length > 0){
+        message += '|#' + merged_tags.join(',');
+    }
+
+    // Only send this stat if we're not a mock Client.
+    if(!this.mock) {
+        if(this.maxBufferSize === 0) {
+            this.sendMessage(message, callback);
+        }
+        else {
+            this.enqueue(message);
+        }
+    }
+    else {
+        if(typeof callback === 'function'){
+            callback(null, 0);
+        }
+    }
 };
 
 /**
@@ -250,68 +249,87 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
  * @param message {String}
  */
 Client.prototype.enqueue = function(message){
-  this.buffer += message + "\n";
-  if(this.buffer.length >= this.maxBufferSize) {
-      this.flushQueue();
-  }
+    this.buffer += message + "\n";
+    if(this.buffer.length >= this.maxBufferSize) {
+        this.flushQueue();
+    }
 }
 
 /**
  *
  */
 Client.prototype.flushQueue = function(){
-  this.sendMessage(this.buffer);
-  this.buffer = "";
+    this.sendMessage(this.buffer);
+    this.buffer = "";
 }
 
 
 /**
  * Close the old socket and create a new one, when desired
  */
-Client.prototype.refreshSocket = function(){
-  var now = new Date();
-  if ((now - this.socketCreateTime) >= this.socketRefreshInterval) {
-    var newSocket = dgram.createSocket('udp4');
-    var oldSocket = this.socket;
-    this.socket = newSocket;
-    this.socketCreateTime = now;
+Client.prototype.refreshSocketAndDns = function(){
+    var now = new Date();
+    if ((now - this.socketCreateTime) >= this.socketRefreshInterval) {
+        var newSocket = dgram.createSocket('udp4');
+        var oldSocket = this.socket;
+        this.socket = newSocket;
+        this.socketCreateTime = now;
 
-    // There is a small window where there may still be unsent data on the old socket
-    // (even 'tho socket.send has already been called).  Closing it in this case
-    // would prevcent that data from being sent.  For that reason, we don't close it
-    // immediately.  Instead, we Close the old socket after a short delay.
-    setTimeout(oldSocket.close.bind(oldSocket), this.socketRefreshInterval);
-  }
+        // There is a small window where there may still be unsent data on the old socket
+        // (even 'tho socket.send has already been called).  Closing it in this case
+        // would prevcent that data from being sent.  For that reason, we don't close it
+        // immediately.  Instead, we Close the old socket after a short delay.
+        setTimeout(oldSocket.close.bind(oldSocket), this.socketRefreshInterval);
+
+        // if cacheDns is enabled, time to refresh the dns name.
+        if (this.cacheDns) {
+            this.refreshDns();
+        }
+    }
 }
 
+/**
+ * refresh the dns resolution periodically. This is useful when k8s moves the statsd pods. No
+ * more need to restart the service.
+ */
+Client.prototype.refreshDns = function(){
+    var self = this;
+    dns.lookup(this.host, function(err, address, family){
+        if(err == null){
+            self.resolvedAddress = address;
+        }
+    });
+}
 /**
  *
  * @param message {String}
  * @param callback {Function}
  */
 Client.prototype.sendMessage = function(message, callback){
-  var buf = new Buffer(message);
-  this.refreshSocket();
-  this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+    var buf = new Buffer(message);
+    this.refreshSocketAndDns();
+
+    var address = this.cacheDns ? this.resolvedAddress : this.host;
+    this.socket.send(buf, 0, buf.length, this.port, address, callback);
 }
 
 /**
  *
  */
 Client.prototype.timeoutCallback = function(){
-  if(this.buffer !== "") {
-    this.flushQueue();
-  }
+    if(this.buffer !== "") {
+        this.flushQueue();
+    }
 }
 
 /**
  * Close the underlying socket and stop listening for data on it.
  */
 Client.prototype.close = function(){
-  if(this.intervalHandle) {
-    clearInterval(this.intervalHandle);
-  }
-  this.socket.close();
+    if(this.intervalHandle) {
+        clearInterval(this.intervalHandle);
+    }
+    this.socket.close();
 }
 
 exports = module.exports = Client;

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -9,16 +9,16 @@ var dgram = require('dgram'),
  * @private
  */
 function udpTest(test, callback){
-  var server = dgram.createSocket("udp4");
-  server.on('message', function(message, rinfo){
-    test(message.toString(), server, rinfo);
-  });
+    var server = dgram.createSocket("udp4");
+    server.on('message', function(message, rinfo){
+        test(message.toString(), server, rinfo);
+    });
 
-  server.on('listening', function(){
-    callback(server);
-  });
+    server.on('listening', function(){
+        callback(server);
+    });
 
-  server.bind(0, '127.0.0.1');
+    server.bind(0, '127.0.0.1');
 }
 
 /**
@@ -26,40 +26,40 @@ function udpTest(test, callback){
  * for this method when used on a mock Client.
  */
 function assertMockClientMethod(method, finished){
- var testFinished = "test finished message";
+    var testFinished = "test finished message";
 
-  udpTest(function(message, server){
-    // We only expect to get our own test finished message, no stats.
-    assert.equal(message, testFinished);
-    server.close();
-    finished();
-  }, function(server){
-    var address = server.address(),
+    udpTest(function(message, server){
+        // We only expect to get our own test finished message, no stats.
+        assert.equal(message, testFinished);
+        server.close();
+        finished();
+    }, function(server){
+        var address = server.address(),
         statsd = new StatsD(address.address, address.port, 'prefix', 'suffix', false, false,
-                            /* mock = true */ true),
-        socket = dgram.createSocket("udp4"),
-        buf = new Buffer(testFinished),
-        callbackThrows = false;
+            /* mock = true */ true),
+            socket = dgram.createSocket("udp4"),
+            buf = new Buffer(testFinished),
+            callbackThrows = false;
 
-    // Regression test for "undefined is not a function" with missing callback on mock instance.
-    try {
-      statsd[method]('test', 1);
-    } catch(e) {
-      callbackThrows = true;
-    }
-    assert.ok(!callbackThrows);
+            // Regression test for "undefined is not a function" with missing callback on mock instance.
+            try {
+                statsd[method]('test', 1);
+            } catch(e) {
+                callbackThrows = true;
+            }
+        assert.ok(!callbackThrows);
 
-    statsd[method]('test', 1, null, function(error, bytes){
-      assert.ok(!error);
-      assert.equal(bytes, 0);
-      // We should call finished() here, but we have to work around
-      // https://github.com/joyent/node/issues/2867 on node 0.6,
-      // such that we don't close the socket within the `listening` event
-      // and pass a single message through instead.
-      socket.send(buf, 0, buf.length, address.port, address.address,
-                  function(){ socket.close(); });
+        statsd[method]('test', 1, null, function(error, bytes){
+            assert.ok(!error);
+            assert.equal(bytes, 0);
+            // We should call finished() here, but we have to work around
+            // https://github.com/joyent/node/issues/2867 on node 0.6,
+            // such that we don't close the socket within the `listening` event
+            // and pass a single message through instead.
+            socket.send(buf, 0, buf.length, address.port, address.address,
+                function(){ socket.close(); });
+        });
     });
-  });
 }
 
 /**
@@ -68,755 +68,863 @@ function assertMockClientMethod(method, finished){
  */
 var oldRandom = Math.random;
 Math.random = function(){
-  return 0.42;
+    return 0.42;
 };
 
 
 describe('StatsD', function(){
-  describe('#init', function(){
-    it('should set default values when not specified', function(){
-      // cachedDns isn't tested here; see below
-      var statsd = new StatsD();
-      assert.equal(statsd.host, 'localhost');
-      assert.equal(statsd.port, 8125);
-      assert.equal(statsd.prefix, '');
-      assert.equal(statsd.suffix, '');
-      assert.equal(global.statsd, undefined);
-      assert.equal(statsd.mock, undefined);
-      assert.deepEqual(statsd.global_tags, []);
-      assert.ok(!statsd.mock);
-    });
-
-    it('should set the proper values when specified', function(){
-      // cachedDns isn't tested here; see below
-      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true, null, true, ['gtag']);
-      assert.equal(statsd.host, 'host');
-      assert.equal(statsd.port, 1234);
-      assert.equal(statsd.prefix, 'prefix');
-      assert.equal(statsd.suffix, 'suffix');
-      assert.equal(statsd, global.statsd);
-      assert.equal(statsd.mock, true);
-      assert.deepEqual(statsd.global_tags, ['gtag']);
-    });
-
-    it('should set the proper values with options hash format', function(){
-      // cachedDns isn't tested here; see below
-      var statsd = new StatsD({
-        host: 'host',
-        port: 1234,
-        prefix: 'prefix',
-        suffix: 'suffix',
-        globalize: true,
-        mock: true,
-        global_tags: ['gtag']
-      });
-      assert.equal(statsd.host, 'host');
-      assert.equal(statsd.port, 1234);
-      assert.equal(statsd.prefix, 'prefix');
-      assert.equal(statsd.suffix, 'suffix');
-      assert.equal(statsd, global.statsd);
-      assert.equal(statsd.mock, true);
-      assert.deepEqual(statsd.global_tags, ['gtag']);
-    });
-
-    it('should attempt to cache a dns record if dnsCache is specified', function(done){
-      var dns = require('dns'),
-          originalLookup = dns.lookup,
-          statsd;
-
-      // replace the dns lookup function with our mock dns lookup
-      dns.lookup = function(host, callback){
-        process.nextTick(function(){
-          dns.lookup = originalLookup;
-          assert.equal(statsd.host, host);
-          callback(null, '127.0.0.1', 4);
-          assert.equal(statsd.host, '127.0.0.1');
-          done();
+    describe('#init', function(){
+        it('should set default values when not specified', function(){
+            // cachedDns isn't tested here; see below
+            var statsd = new StatsD();
+            assert.equal(statsd.host, 'localhost');
+            assert.equal(statsd.port, 8125);
+            assert.equal(statsd.prefix, '');
+            assert.equal(statsd.suffix, '');
+            assert.equal(global.statsd, undefined);
+            assert.equal(statsd.mock, undefined);
+            assert.deepEqual(statsd.global_tags, []);
+            assert.ok(!statsd.mock);
         });
-      };
 
-      statsd = new StatsD({host: 'localhost', cacheDns: true});
-    });
+        it('should set the proper values when specified', function(){
+            // cachedDns isn't tested here; see below
+            var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true, null, true, ['gtag']);
+            assert.equal(statsd.host, 'host');
+            assert.equal(statsd.port, 1234);
+            assert.equal(statsd.prefix, 'prefix');
+            assert.equal(statsd.suffix, 'suffix');
+            assert.equal(statsd, global.statsd);
+            assert.equal(statsd.mock, true);
+            assert.deepEqual(statsd.global_tags, ['gtag']);
+        });
 
-    it('should not attempt to cache a dns record if dnsCache is specified', function(done){
-      var dns = require('dns'),
-          originalLookup = dns.lookup,
-          statsd;
-
-      // replace the dns lookup function with our mock dns lookup
-      dns.lookup = function(host, callback){
-        assert.ok(false, 'StatsD constructor should not invoke dns.lookup when dnsCache is unspecified');
-        dns.lookup = originalLookup;
-      };
-
-      statsd = new StatsD({host: 'localhost'});
-      process.nextTick(function(){
-        dns.lookup = originalLookup;
-        done();
-      });
-    });
-
-    it('should create a global variable set to StatsD() when specified', function(){
-      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true);
-      assert.ok(global.statsd instanceof StatsD);
-      //remove it from the namespace to not fail other tests
-      delete global.statsd;
-    });
-
-    it('should not create a global variable when not specified', function(){
-      var statsd = new StatsD('host', 1234, 'prefix', 'suffix');
-      assert.equal(global.statsd, undefined);
-    });
-
-    it('should create a mock Client when mock variable is specified', function(){
-      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', false, false, true);
-      assert.ok(statsd.mock);
-    });
-
-    it('should create a socket variable that is an instance of dgram.Socket', function(){
-      var statsd = new StatsD();
-      assert.ok(statsd.socket instanceof dgram.Socket);
-    });
-
-  });
-
-  describe('#global_tags', function(){
-    it('should not add global tags if they are not specified', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:1|c');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.increment('test');
-      });
-    });
-
-    it('should add global tags if they are specified', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:1|c|#gtag');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD({
-              host: address.address,
-              port: address.port,
-              global_tags: ['gtag']
+        it('should set the proper values with options hash format', function(){
+            // cachedDns isn't tested here; see below
+            var statsd = new StatsD({
+                host: 'host',
+                port: 1234,
+                prefix: 'prefix',
+                suffix: 'suffix',
+                globalize: true,
+                mock: true,
+                global_tags: ['gtag']
             });
+            assert.equal(statsd.host, 'host');
+            assert.equal(statsd.port, 1234);
+            assert.equal(statsd.prefix, 'prefix');
+            assert.equal(statsd.suffix, 'suffix');
+            assert.equal(statsd, global.statsd);
+            assert.equal(statsd.mock, true);
+            assert.deepEqual(statsd.global_tags, ['gtag']);
+        });
 
-        statsd.increment('test');
-      });
-    });
+        it('should attempt to cache a dns record if dnsCache is specified', function(done){
+            var dns = require('dns'),
+            originalLookup = dns.lookup,
+            statsd;
 
-    it('should combine global tags and metric tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:1337|c|#foo,gtag');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD({
-              host: address.address,
-              port: address.port,
-              global_tags: ['gtag']
+            // replace the dns lookup function with our mock dns lookup
+            dns.lookup = function(host, callback){
+                process.nextTick(function(){
+                    dns.lookup = originalLookup;
+                    assert.equal(statsd.host, host);
+                    callback(null, '127.0.0.1', 4);
+                    assert.equal(statsd.resolvedAddress, '127.0.0.1');
+                    done();
+                });
+            };
+
+            statsd = new StatsD({host: 'localhost', cacheDns: true});
+        });
+
+        it('should not attempt to cache a dns record if dnsCache is specified', function(done){
+            var dns = require('dns'),
+            originalLookup = dns.lookup,
+            statsd;
+
+            // replace the dns lookup function with our mock dns lookup
+            dns.lookup = function(host, callback){
+                assert.ok(false, 'StatsD constructor should not invoke dns.lookup when dnsCache is unspecified');
+                dns.lookup = originalLookup;
+            };
+
+            statsd = new StatsD({host: 'localhost'});
+            process.nextTick(function(){
+                dns.lookup = originalLookup;
+                done();
             });
-
-        statsd.increment('test', 1337, ['foo']);
-      });
-    });
-  });
-
-  describe('#timing', function(finished){
-    it('should send proper time format without prefix, suffix, sampling and callback', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|ms');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.timing('test', 42);
-      });
-    });
-
-    it('should send proper time format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|ms|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.timing('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper time format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:42|ms|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.timing('test', 42, 0.5, function(){
-          called = true;
         });
-      });
-    });
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = false,
-          messageNumber = 0;
-
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:42|ms');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:42|ms');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.timing(['a', 'b'], 42, null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 14);
+        it('should create a global variable set to StatsD() when specified', function(){
+            var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true);
+            assert.ok(global.statsd instanceof StatsD);
+            //remove it from the namespace to not fail other tests
+            delete global.statsd;
         });
-      });
-    });
 
-    it('should send no timing stat when a mock Client is used', function(finished){
-      assertMockClientMethod('timing', finished);
-    });
-  });
-
-  describe('#histogram', function(finished){
-    it('should send proper histogram format without prefix, suffix, sampling and callback', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|h');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.histogram('test', 42);
-      });
-    });
-
-    it('should send proper histogram format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|h|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.histogram('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper histogram format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:42|h|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.histogram('test', 42, 0.5, function(){
-          called = true;
+        it('should not create a global variable when not specified', function(){
+            var statsd = new StatsD('host', 1234, 'prefix', 'suffix');
+            assert.equal(global.statsd, undefined);
         });
-      });
-    });
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = 0,
-          messageNumber = 0;
-
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:42|h');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:42|h');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.histogram(['a', 'b'], 42, null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 12);
+        it('should create a mock Client when mock variable is specified', function(){
+            var statsd = new StatsD('host', 1234, 'prefix', 'suffix', false, false, true);
+            assert.ok(statsd.mock);
         });
-      });
-    });
 
-    it('should send no histogram stat when a mock Client is used', function(finished){
-      assertMockClientMethod('histogram', finished);
-    });
-  });
-
-  describe('#gauge', function(finished){
-    it('should send proper gauge format without prefix, suffix, sampling and callback', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|g');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.gauge('test', 42);
-      });
-    });
-
-    it('should send proper gauge format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|g|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.gauge('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper gauge format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:42|g|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.gauge('test', 42, 0.5, function(){
-          called = true;
+        it('should create a socket variable that is an instance of dgram.Socket', function(){
+            var statsd = new StatsD();
+            assert.ok(statsd.socket instanceof dgram.Socket);
         });
-      });
+
     });
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = 0,
-          messageNumber = 0;
+    describe('#global_tags', function(){
+        it('should not add global tags if they are not specified', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:1|c');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:42|g');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:42|g');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.gauge(['a', 'b'], 42, null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 12);
+                statsd.increment('test');
+            });
         });
-      });
-    });
 
-    it('should send no gauge stat when a mock Client is used', function(finished){
-      assertMockClientMethod('gauge', finished);
-    });
-  });
+        it('should add global tags if they are specified', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:1|c|#gtag');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD({
+                    host: address.address,
+                    port: address.port,
+                    global_tags: ['gtag']
+                });
 
-  describe('#increment', function(finished){
-    it('should send count by 1 when no params are specified', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:1|c');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.increment('test');
-      });
-    });
-
-    it('should send proper count format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|c|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.increment('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper count format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:42|c|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.increment('test', 42, 0.5, function(){
-          called = true;
+                statsd.increment('test');
+            });
         });
-      });
-    });
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = 0,
-          messageNumber = 0;
+        it('should combine global tags and metric tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:1337|c|#foo,gtag');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD({
+                    host: address.address,
+                    port: address.port,
+                    global_tags: ['gtag']
+                });
 
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:1|c');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:1|c');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.increment(['a', 'b'], null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 10);
+                statsd.increment('test', 1337, ['foo']);
+            });
         });
-      });
     });
 
-    it('should send no increment stat when a mock Client is used', function(finished){
-      assertMockClientMethod('increment', finished);
-    });
-  });
+    describe('#timing', function(finished){
+        it('should send proper time format without prefix, suffix, sampling and callback', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|ms');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-  describe('#decrement', function(finished){
-    it('should send count by -1 when no params are specified', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:-1|c');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.decrement('test');
-      });
-    });
-
-    it('should send proper count format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:-42|c|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.decrement('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper count format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:-42|c|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.decrement('test', 42, 0.5, function(){
-          called = true;
+                statsd.timing('test', 42);
+            });
         });
-      });
-    });
 
+        it('should send proper time format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|ms|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = 0,
-          messageNumber = 0;
-
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:-1|c');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:-1|c');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.decrement(['a', 'b'], null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 12);
+                statsd.timing('test', 42, ['foo', 'bar']);
+            });
         });
-      });
-    });
 
-    it('should send no decrement stat when a mock Client is used', function(finished){
-      assertMockClientMethod('decrement', finished);
-    });
-  });
+        it('should send proper time format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:42|ms|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
 
-  describe('#set', function(finished){
-    it('should send proper set format without prefix, suffix, sampling and callback', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|s');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.set('test', 42);
-      });
-    });
-
-    it('should send proper set format with tags', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|s|#foo,bar');
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.set('test', 42, ['foo', 'bar']);
-      });
-    });
-
-    it('should send proper set format with prefix, suffix, sampling and callback', function(finished){
-      var called = false;
-      udpTest(function(message, server){
-        assert.equal(message, 'foo.test.bar:42|s|@0.5');
-        assert.equal(called, true);
-        server.close();
-        finished();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
-
-        statsd.unique('test', 42, 0.5, function(){
-          called = true;
+                statsd.timing('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
         });
-      });
-    });
 
-    it('should properly send a and b with the same value', function(finished){
-      var called = 0,
-          messageNumber = 0;
+        it('should properly send a and b with the same value', function(finished){
+            var called = false,
+            messageNumber = 0;
 
-      udpTest(function(message, server){
-        if(messageNumber === 0){
-          assert.equal(message, 'a:42|s');
-          messageNumber += 1;
-        } else {
-          assert.equal(message, 'b:42|s');
-          server.close();
-          finished();
-        }
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:42|ms');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:42|ms');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
 
-        statsd.unique(['a', 'b'], 42, null, function(error, bytes){
-          called += 1;
-          assert.ok(called === 1); //ensure it only gets called once
-          assert.equal(error, null);
-          assert.equal(bytes, 12);
+                statsd.timing(['a', 'b'], 42, null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 14);
+                });
+            });
         });
-      });
+
+        it('should send no timing stat when a mock Client is used', function(finished){
+            assertMockClientMethod('timing', finished);
+        });
     });
 
-    it('should send no set stat when a mock Client is used', function(finished){
-      assertMockClientMethod('set', finished);
-    });
-  });
-  describe('buffer', function() {
-    it('should aggregate packets when maxBufferSize is set to non-zero', function (finished) {
-      udpTest(function (message, server) {
-        assert.equal(message, 'a:1|c\nb:2|c\n');
-        server.close();
-        finished();
-      }, function (server) {
-        var address = server.address();
-        var options = {
-          host: address.host,
-          port: address.port,
-          maxBufferSize: 8
-        };
-        var statsd = new StatsD(options);
+    describe('#histogram', function(finished){
+        it('should send proper histogram format without prefix, suffix, sampling and callback', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|h');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-        statsd.increment('a', 1);
-        statsd.increment('b', 2);
-      });
-    });
+                statsd.histogram('test', 42);
+            });
+        });
 
-    it('should not aggregate packets when maxBufferSize is set to zero', function (finished) {
-      var results = [
-        'a:1|c',
-        'b:2|c'
-      ];
-      var msgCount = 0;
-      udpTest(function (message, server) {
-        var index = results.indexOf(message);
-        assert.equal(index >= 0, true);
-        results.splice(index, 1);
-        msgCount++;
-        if (msgCount >= 2) {
-          assert.equal(results.length, 0);
-          server.close();
-          finished();
-        }
-      }, function (server) {
-        var address = server.address();
-        var options = {
-          host: address.host,
-          port: address.port,
-          maxBufferSize: 0
-        };
-        var statsd = new StatsD(options);
+        it('should send proper histogram format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|h|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-        statsd.increment('a', 1);
-        statsd.increment('b', 2);
-      });
-    });
+                statsd.histogram('test', 42, ['foo', 'bar']);
+            });
+        });
 
-    it('should flush the buffer when timeout value elapsed', function (finished) {
-      var timestamp;
-      udpTest(function (message, server) {
-        assert.equal(message, 'a:1|c\n');
-        var elapsed = Date.now() - timestamp;
-        assert.equal(elapsed > 1000, true);
-        server.close();
-        finished();
-      }, function (server) {
-        var address = server.address();
-        var options = {
-          host: address.host,
-          port: address.port,
-          maxBufferSize: 1220,
-          bufferFlushInterval: 1100
-        };
-        var statsd = new StatsD(options);
+        it('should send proper histogram format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:42|h|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
 
-        timestamp = new Date();
-        statsd.increment('a', 1);
-      });
-    });
-  });
-  describe('socketRefresh', function(){
-    it('should reuse the same socket when sending multiple messages quickly', function(finished){
+                statsd.histogram('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
+        });
 
-      var numMessagesReceived = 0;
-      var firstRinfo = null;
+        it('should properly send a and b with the same value', function(finished){
+            var called = 0,
+            messageNumber = 0;
 
-      udpTest(function(message, server, rInfo){
-        numMessagesReceived++;
-        assert.equal(message, 'test:1|c');
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:42|h');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:42|h');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
 
-        if (numMessagesReceived === 1) {
-          firstRinfo = rInfo;
-        } else {
-          assert.equal(numMessagesReceived, 2);
-          assert.equal(firstRinfo.port, rInfo.port);
-          server.close();
-          finished();
-        }
-      }, function(server) {
-        var address = server.address();
-        var options = {
-          host: address.host,
-          port: address.port,
-          maxBufferSize: 0
-        };
-        var statsd = new StatsD(options);
+                statsd.histogram(['a', 'b'], 42, null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 12);
+                });
+            });
+        });
 
-        statsd.increment('test');
-        statsd.increment('test');
-      });
+        it('should send no histogram stat when a mock Client is used', function(finished){
+            assertMockClientMethod('histogram', finished);
+        });
     });
 
-    it('should use a new socket after the specified interval', function(finished){
+    describe('#gauge', function(finished){
+        it('should send proper gauge format without prefix, suffix, sampling and callback', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|g');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-      var numMessagesReceived = 0;
-      var firstRinfo = null;
+                statsd.gauge('test', 42);
+            });
+        });
 
-      udpTest(function(message, server, rInfo){
-        numMessagesReceived++;
-        assert.equal(message, 'test:1|c');
+        it('should send proper gauge format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|g|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
 
-        if (numMessagesReceived === 1) {
-          firstRinfo = rInfo;
-        } else {
-          assert.equal(numMessagesReceived, 2);
-          assert.notEqual(firstRinfo.port, rInfo.port);
-          server.close();
-          finished();
-        }
-      }, function(server) {
-        var address = server.address();
-        var options = {
-          host: address.host,
-          port: address.port,
-          maxBufferSize: 0,
-          socketRefreshInterval: 1 // 1ms
-        };
-        var statsd = new StatsD(options);
+                statsd.gauge('test', 42, ['foo', 'bar']);
+            });
+        });
 
-        statsd.increment('test');
-        // Send a second metric after a delay (10ms)
-        setTimeout(function() {
-          statsd.increment('test');
-        }, 10);
-      });
+        it('should send proper gauge format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:42|g|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
+
+                statsd.gauge('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
+        });
+
+        it('should properly send a and b with the same value', function(finished){
+            var called = 0,
+            messageNumber = 0;
+
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:42|g');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:42|g');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
+
+                statsd.gauge(['a', 'b'], 42, null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 12);
+                });
+            });
+        });
+
+        it('should send no gauge stat when a mock Client is used', function(finished){
+            assertMockClientMethod('gauge', finished);
+        });
     });
-  });
+
+    describe('#increment', function(finished){
+        it('should send count by 1 when no params are specified', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:1|c');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.increment('test');
+            });
+        });
+
+        it('should send proper count format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|c|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.increment('test', 42, ['foo', 'bar']);
+            });
+        });
+
+        it('should send proper count format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:42|c|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
+
+                statsd.increment('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
+        });
+
+        it('should properly send a and b with the same value', function(finished){
+            var called = 0,
+            messageNumber = 0;
+
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:1|c');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:1|c');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
+
+                statsd.increment(['a', 'b'], null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 10);
+                });
+            });
+        });
+
+        it('should send no increment stat when a mock Client is used', function(finished){
+            assertMockClientMethod('increment', finished);
+        });
+    });
+
+    describe('#decrement', function(finished){
+        it('should send count by -1 when no params are specified', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:-1|c');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.decrement('test');
+            });
+        });
+
+        it('should send proper count format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:-42|c|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.decrement('test', 42, ['foo', 'bar']);
+            });
+        });
+
+        it('should send proper count format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:-42|c|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
+
+                statsd.decrement('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
+        });
+
+
+        it('should properly send a and b with the same value', function(finished){
+            var called = 0,
+            messageNumber = 0;
+
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:-1|c');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:-1|c');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
+
+                statsd.decrement(['a', 'b'], null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 12);
+                });
+            });
+        });
+
+        it('should send no decrement stat when a mock Client is used', function(finished){
+            assertMockClientMethod('decrement', finished);
+        });
+    });
+
+    describe('#set', function(finished){
+        it('should send proper set format without prefix, suffix, sampling and callback', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|s');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.set('test', 42);
+            });
+        });
+
+        it('should send proper set format with tags', function(finished){
+            udpTest(function(message, server){
+                assert.equal(message, 'test:42|s|#foo,bar');
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port);
+
+                statsd.set('test', 42, ['foo', 'bar']);
+            });
+        });
+
+        it('should send proper set format with prefix, suffix, sampling and callback', function(finished){
+            var called = false;
+            udpTest(function(message, server){
+                assert.equal(message, 'foo.test.bar:42|s|@0.5');
+                assert.equal(called, true);
+                server.close();
+                finished();
+            }, function(server){
+                var address = server.address(),
+                statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
+
+                statsd.unique('test', 42, 0.5, function(){
+                    called = true;
+                });
+            });
+        });
+
+        it('should properly send a and b with the same value', function(finished){
+            var called = 0,
+            messageNumber = 0;
+
+            udpTest(function(message, server){
+                if(messageNumber === 0){
+                    assert.equal(message, 'a:42|s');
+                    messageNumber += 1;
+                } else {
+                    assert.equal(message, 'b:42|s');
+                    server.close();
+                    finished();
+                }
+            }, function(server){
+                var address = server.address(),
+                    statsd = new StatsD(address.address, address.port);
+
+                statsd.unique(['a', 'b'], 42, null, function(error, bytes){
+                    called += 1;
+                    assert.ok(called === 1); //ensure it only gets called once
+                    assert.equal(error, null);
+                    assert.equal(bytes, 12);
+                });
+            });
+        });
+
+        it('should send no set stat when a mock Client is used', function(finished){
+            assertMockClientMethod('set', finished);
+        });
+    });
+    describe('buffer', function() {
+        it('should aggregate packets when maxBufferSize is set to non-zero', function (finished) {
+            udpTest(function (message, server) {
+                assert.equal(message, 'a:1|c\nb:2|c\n');
+                server.close();
+                finished();
+            }, function (server) {
+                var address = server.address();
+                var options = {
+                    host: address.host,
+                    port: address.port,
+                    maxBufferSize: 8
+                };
+                var statsd = new StatsD(options);
+
+                statsd.increment('a', 1);
+                statsd.increment('b', 2);
+            });
+        });
+
+        it('should not aggregate packets when maxBufferSize is set to zero', function (finished) {
+            var results = [
+                'a:1|c',
+                'b:2|c'
+            ];
+            var msgCount = 0;
+            udpTest(function (message, server) {
+                var index = results.indexOf(message);
+                assert.equal(index >= 0, true);
+                results.splice(index, 1);
+                msgCount++;
+                if (msgCount >= 2) {
+                    assert.equal(results.length, 0);
+                    server.close();
+                    finished();
+                }
+            }, function (server) {
+                var address = server.address();
+                var options = {
+                    host: address.host,
+                    port: address.port,
+                    maxBufferSize: 0
+                };
+                var statsd = new StatsD(options);
+
+                statsd.increment('a', 1);
+                statsd.increment('b', 2);
+            });
+        });
+
+        it('should flush the buffer when timeout value elapsed', function (finished) {
+            var timestamp;
+            udpTest(function (message, server) {
+                assert.equal(message, 'a:1|c\n');
+                var elapsed = Date.now() - timestamp;
+                assert.equal(elapsed > 1000, true);
+                server.close();
+                finished();
+            }, function (server) {
+                var address = server.address();
+                var options = {
+                    host: address.host,
+                    port: address.port,
+                    maxBufferSize: 1220,
+                    bufferFlushInterval: 1100
+                };
+                var statsd = new StatsD(options);
+
+                timestamp = new Date();
+                statsd.increment('a', 1);
+            });
+        });
+    });
+    describe('socketRefresh', function(){
+        it('should reuse the same socket when sending multiple messages quickly', function(finished){
+
+            var numMessagesReceived = 0;
+            var firstRinfo = null;
+
+            udpTest(function(message, server, rInfo){
+                numMessagesReceived++;
+                assert.equal(message, 'test:1|c');
+
+                if (numMessagesReceived === 1) {
+                    firstRinfo = rInfo;
+                } else {
+                    assert.equal(numMessagesReceived, 2);
+                    assert.equal(firstRinfo.port, rInfo.port);
+                    server.close();
+                    finished();
+                }
+            }, function(server) {
+                var address = server.address();
+                var options = {
+                    host: address.host,
+                    port: address.port,
+                    maxBufferSize: 0
+                };
+                var statsd = new StatsD(options);
+
+                statsd.increment('test');
+                statsd.increment('test');
+            });
+        });
+
+        it('should use a new socket after the specified interval', function(finished){
+
+            var numMessagesReceived = 0;
+            var firstRinfo = null;
+
+            udpTest(function(message, server, rInfo){
+                numMessagesReceived++;
+                assert.equal(message, 'test:1|c');
+
+                if (numMessagesReceived === 1) {
+                    firstRinfo = rInfo;
+                } else {
+                    assert.equal(numMessagesReceived, 2);
+                    assert.notEqual(firstRinfo.port, rInfo.port);
+                    server.close();
+                    finished();
+                }
+            }, function(server) {
+                var address = server.address();
+                var options = {
+                    host: address.host,
+                    port: address.port,
+                    maxBufferSize: 0,
+                    socketRefreshInterval: 1 // 1ms
+                };
+                var statsd = new StatsD(options);
+
+                statsd.increment('test');
+                // Send a second metric after a delay (10ms)
+                setTimeout(function() {
+                    statsd.increment('test');
+                }, 10);
+            });
+        });
+    });
+
+    describe('refreshDns', function(){
+        it('should use 127.0.0.1 when dns fails', function(done){
+            var dgram = require('dgram'),
+            mockDgramSocket,
+            server,
+            statsd;
+
+            mockDgramSocket = {
+                send: function(buffer, offset, length, port, address, callback) {
+                    assert.equal(address, '127.0.0.1');
+                    done();
+                }
+            };
+            dgram.createSocket = function() {
+                return mockDgramSocket;
+            }
+
+            statsd = new StatsD({host: 'badAddress', cacheDns: true});
+            setTimeout(statsd.sendMessage.bind(statsd, 'foobar'), 100);
+        });
+
+        it('should use the same address when call closely', function(done){
+            var dns = require('dns'),
+            originalLookup = dns.lookup,
+            dgram = require('dgram'),
+            mockDgramSocket,
+            server,
+            statsd;
+
+            //replace the dns lookup function with our mock dns lookup
+            dns.lookup = function(host, callback){
+                if (host == 'mockAddress') {
+                    process.nextTick(function(){
+                        callback(null, '1.2.3.4', 4);
+                    });
+                }
+                else {
+                    originalLookup(host, callback);
+                }
+            };
+
+            var callCount = 0;
+            mockDgramSocket = {
+                send: function(buffer, offset, length, port, address, callback) {
+                    assert.equal(address, '1.2.3.4');
+                    callCount++;
+                    if(callCount == 2) {
+                        done();
+                    }
+                }
+            };
+            dgram.createSocket = function() {
+                return mockDgramSocket;
+            }
+
+            statsd = new StatsD({host: 'mockAddress', cacheDns: true});
+            setTimeout(statsd.sendMessage.bind(statsd, 'foobar'), 100);
+            setTimeout(statsd.sendMessage.bind(statsd, 'foobar'), 101);
+        });
+        it('should use different addresses when refresh happenning in between calls return different results', function(done){
+            var dns = require('dns'),
+            originalLookup = dns.lookup,
+            dgram = require('dgram'),
+            mockDgramSocket,
+            firstResultReturned,
+            server,
+            statsd;
+
+            //replace the dns lookup function with our mock dns lookup
+            dns.lookup = function(host, callback){
+                if (host == 'mockAddress') {
+                    process.nextTick(function(){
+                        if(!firstResultReturned) {
+                            callback(null, '1.2.3.4', 4);
+                        }
+                        else {
+                            callback(null, '4.3.2.1', 4);
+                        }
+                    });
+                }
+                else {
+                    originalLookup(host, callback);
+                }
+            };
+
+            mockDgramSocket = {
+                send: function(buffer, offset, length, port, address, callback) {
+                    if(!firstResultReturned) {
+                        assert.equal(address, '1.2.3.4');
+                    }
+                    else {
+                        assert.equal(address, '4.3.2.1');
+                        done();
+                    }
+                    firstResultReturned = true;
+                },
+                close: function() {}
+            };
+            dgram.createSocket = function() {
+                return mockDgramSocket;
+            }
+
+            statsd = new StatsD({host: 'mockAddress', cacheDns: true, socketRefreshInterval: 1});
+            setTimeout(statsd.sendMessage.bind(statsd, 'foobar'), 100);
+            setTimeout(statsd.sendMessage.bind(statsd, 'foobar'), 200);
+        });
+    });
 });

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -821,7 +821,7 @@ describe('StatsD', function(){
     });
 
     describe('refreshDns', function(){
-        it('should use 127.0.0.1 when dns fails', function(done){
+        it('should use orignal host when dns fails', function(done){
             var dgram = require('dgram'),
             mockDgramSocket,
             server,
@@ -829,7 +829,7 @@ describe('StatsD', function(){
 
             mockDgramSocket = {
                 send: function(buffer, offset, length, port, address, callback) {
-                    assert.equal(address, '127.0.0.1');
+                    assert.equal(address, 'badAddress');
                     done();
                 }
             };


### PR DESCRIPTION
First I reformat the files from ts=2 to ts=4.  Please add `?w=1` when you review the diffs.

In k8s sometimes we move the statsd instances, `statsd.production` could point to different addresses at different time.  Since we had cacheDns set to true, currently we have to bounce the services to pick up the new addresses.

This is to fix the problem.  At the same interval we refresh the socket, I added code to refresh dns record too.  Some the metrics will be lost for at most a minute(the default interval).

This doesn't address the service restarts caused by dns failure.  I will have a different pr in hurley-metrics to fix that.