### PR TITLE
add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,22 @@ If an array is specified as the `name` parameter each item in that array will be
 
 ## Errors
 
-In the event that there is a socket error, `node-statsd` will allow this error to bubble up.  If you would like to catch the errors, just attach a listener to the socket property on the instance.
+Original from sivy/node-statsd:
+
+> In the event that there is a socket error, `node-statsd` will allow this error to bubble up.  If you would like to catch the errors, just attach a listener to the socket property on the instance.
 
 ```javascript
 client.socket.on('error', function(error) {
   return console.error("Error in socket: ", error);
 });
 ```
+
+HBO/k8s specific:
+
+Because we recreate the socket every minute, we cannot rely on the caller to do error handling, because they are not exposed to the newly created sockets.
+
+Instead an error handler should be passed down in options, and will be attached to every socket created.
+
 
 If you want to catch errors in sending a message then use the callback provided.
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -17,7 +17,7 @@ var dgram = require('dgram'),
  *   @option socketRefreshInterval {Number} The maximum amount of time to use one second in milliseconds (default 1 minute)
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval, socketRefreshInterval) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval, socketRefreshInterval, errorHandler) {
   var options = host || {},
          self = this;
 
@@ -33,7 +33,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       global_tags : global_tags,
       maxBufferSize : maxBufferSize,
       bufferFlushInterval: bufferFlushInterval,
-      socketRefreshInterval: socketRefreshInterval
+      socketRefreshInterval: socketRefreshInterval,
+      errorHandler: errorHandler
     };
   }
 
@@ -49,9 +50,14 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.buffer = "";
   this.socketRefreshInterval = options.socketRefreshInterval || 60000; // 1 minute
+  this.errorHandler =options.errorHandler;
 
   if(this.maxBufferSize > 0) {
     this.intervalHandle = setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
+  }
+
+  if (this.errorHandler) {
+    this.socket.on('error', this.errorHandler);
   }
 
   if(options.cacheDns === true){
@@ -275,6 +281,10 @@ Client.prototype.refreshSocket = function(){
     var oldSocket = this.socket;
     this.socket = newSocket;
     this.socketCreateTime = now;
+
+    if (this.errorHandler) {
+      this.socket.on('error', this.errorHandler);
+    }
 
     // There is a small window where there may still be unsent data on the old socket
     // (even 'tho socket.send has already been called).  Closing it in this case


### PR DESCRIPTION
I was working on this pr https://github.com/HBOCodeLabs/Hurley-Metrics/pull/2, then I realized I cannot do error handling there, as the original README said, because we recreate the socket every minute.

So I make errorHandler part of the options, and attach it to every socket created.