### PR TITLE
retry dns caching until success

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -327,7 +327,7 @@ Client.prototype.close = function(){
 Client.prototype.resolveAddress = function() {
   var self = this;
   dns.lookup(this.host, function(err, address, family){
-    if(err == null){
+    if (err == null){
       self.host = address;
     }
     else {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -60,12 +60,9 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
     this.socket.on('error', this.errorHandler);
   }
 
+  this.cacheDns = options.cacheDns;
   if(options.cacheDns === true){
-    dns.lookup(options.host, function(err, address, family){
-      if(err == null){
-        self.host = address;
-      }
-    });
+    this.resolveAddress();
   }
 
   if(options.globalize){
@@ -322,6 +319,22 @@ Client.prototype.close = function(){
     clearInterval(this.intervalHandle);
   }
   this.socket.close();
+}
+
+/**
+ *
+ */
+Client.prototype.resolveAddress = function() {
+  var self = this;
+  dns.lookup(this.host, function(err, address, family){
+    if(err == null){
+      self.host = address;
+    }
+    else {
+      // refresh every minute until succeeded.
+      setTimeout(self.resolveAddress.bind(self), 60*1000);
+    }
+  });
 }
 
 exports = module.exports = Client;


### PR DESCRIPTION
Now that I added the error handling to prevent service crashing, we run the risk of overloading kubedns if the first try to cache dns fails, because all the subsequent sendMessage calls will need to resolve this.host.  So I add the retry logic for dns caching.