### PR TITLE
Treat 0 as valid increment

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -91,7 +91,11 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
+  if(value === undefined || value === null) {
+    value = 1;
+  }
+
+  this.sendAll(stat, value, 'c', sampleRate, tags, callback);
 };
 
 /**
@@ -103,7 +107,10 @@ Client.prototype.increment = function (stat, value, sampleRate, tags, callback) 
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
+  if(value === undefined || value === null){
+    value = 1;
+  }
+  this.sendAll(stat, -value, 'c', sampleRate, tags, callback);
 };
 
 /**

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -468,6 +468,19 @@ describe('StatsD', function(){
       });
     });
 
+    it('should send count by 0 when 0 is specified', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:0|c');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.increment('test', 0);
+      });
+    });
+
     it('should send proper count format with tags', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|c|#foo,bar');
@@ -540,6 +553,19 @@ describe('StatsD', function(){
             statsd = new StatsD(address.address, address.port);
 
         statsd.decrement('test');
+      });
+    });
+
+    it('should send count by 0 when 0 is specified', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:0|c');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.decrement('test', 0);
       });
     });
 


### PR DESCRIPTION
### Description
Current the library has a bug:

A `increment(0)` is treated as `increment()`, so it reports `1` instead of `0`.
